### PR TITLE
Fix history folder typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ null*
 .DS_Store
 
 # Add below lines to exclude Obsidian cache
-.histry/
+.history/


### PR DESCRIPTION
## Summary
- fix `.history` folder name in `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d16d873a483278e0f8d69cc32b29f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Corrected a typo in the ignore list to properly exclude the Obsidian cache folder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->